### PR TITLE
Support any input type to table row

### DIFF
--- a/src/main/kotlin/de/m3y/kformat/Table.kt
+++ b/src/main/kotlin/de/m3y/kformat/Table.kt
@@ -479,12 +479,12 @@ class Table internal constructor() {
                             when (v) {
                                 is CharSequence -> ("%" + formatFlags + "s").format(v).length
                                 is Int -> ("%" + formatFlags + "d").format(v).length
+                                is Long -> ("%" + formatFlags + "d").format(v).length
+                                is Boolean -> ("%" + formatFlags + "b").format(v).length
                                 is Float -> length(v.toDouble(), hints.precision(i), formatFlags)
                                 is Double -> length(v, hints.precision(i), formatFlags)
                                 is LocalDateTime -> v.toString().length
-                                else -> {
-                                    throw IllegalStateException("Value '$v' of type '${v.javaClass}' in row[$i] not supported")
-                                }
+                                else -> v.toString().length
                             } + valueExtraLength
                         )
                     }
@@ -543,14 +543,12 @@ class Table internal constructor() {
                 when (v) {
                     is CharSequence -> formatSpec.append("s")
                     is Int -> formatSpec.append("d")
+                    is Long -> formatSpec.append("d")
+                    is Boolean -> formatSpec.append("b")
                     is Float, is Double -> formatSpec.append(getPrecisionFormat(columnIndex)).append("f")
                     // 2019-10-25T10:03:13.000+02:00
                     is LocalDateTime -> formatSpec.append("s")
-                    else -> {
-                        throw IllegalArgumentException(
-                            "Unsupported value '$v' of type '${v.javaClass}' in row[$columnIndex]"
-                        )
-                    }
+                    else -> formatSpec.append("s")
                 }
 
                 // Postfix

--- a/src/test/kotlin/de/m3y/kformat/TableTest.kt
+++ b/src/test/kotlin/de/m3y/kformat/TableTest.kt
@@ -523,6 +523,25 @@ A B12345  C1 Dddddddd     Foo Bar
             """.trimIndent()
         )
     }
+
+    @Test
+    fun testAnyRowType() {
+        data class Dummy(val a: Long)
+
+        assertThat(table {
+            row(10L, true, false, Dummy(1))
+
+            hints {
+                alignment(0, Hints.Alignment.LEFT)
+                alignment(1, Hints.Alignment.RIGHT)
+                borderStyle = Table.BorderStyle.SINGLE_LINE
+            }
+        }.render().trim()).isEqualTo(
+            """
+            10 | true | false | Dummy(a=1)
+            """.trimIndent()
+        )
+    }
 }
 
 fun main() {


### PR DESCRIPTION
Started using this framework and it was really nice for creating quick tables 🎉 
However, I would expect that `vararg Any` would actually accept any input. 
Had especially problems with booleans, Longs and Data classes, so this change adds support for them