### PR TITLE
Adds methods toString and print to a stream

### DIFF
--- a/src/main/kotlin/de/m3y/kformat/Table.kt
+++ b/src/main/kotlin/de/m3y/kformat/Table.kt
@@ -2,6 +2,7 @@ package de.m3y.kformat
 
 import de.m3y.kformat.Table.BorderStyle.Companion.NONE
 import de.m3y.kformat.Table.BorderStyle.Companion.SINGLE_LINE
+import java.io.PrintStream
 import java.time.LocalDateTime
 import kotlin.math.max
 
@@ -395,6 +396,22 @@ class Table internal constructor() {
             }
         }
         return out
+    }
+
+    /**
+     * Renders this table to a formatted string.
+     */
+    override fun toString(): String {
+        return render().toString()
+    }
+
+    /**
+     * Prints this table to a stream
+     *
+     * [printStream] stream to print to. Defaults to System.out
+     */
+    fun print(printStream: PrintStream = System.out) {
+        printStream.println(toString())
     }
 
     /**


### PR DESCRIPTION
Would also be nice to more quickly be able to format/print a table. 
Right now the pattern to print the table to stdout is:
```
table {
...
}
  .render()
  .also { println(it) }
```

An alternative would be to add overload `fun render(printStream: PrintStream = System.out)` 🤔 